### PR TITLE
Update CMakeLists.txt to use PROJECT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,41 +34,41 @@ option(BUILD_EXAMPLES   "Build the ZED Open Capture examples"                   
 ############################################################################
 # Sources
 set(SRC_VIDEO
-    ${CMAKE_HOME_DIRECTORY}/src/videocapture.cpp
+    ${PROJECT_SOURCE_DIR}/src/videocapture.cpp
 )
 
 set(SRC_SENSORS
-    ${CMAKE_HOME_DIRECTORY}/src/sensorcapture.cpp
+    ${PROJECT_SOURCE_DIR}/src/sensorcapture.cpp
 )
 
 ############################################################################
 # Includes
 set(HEADERS_VIDEO
     # Base
-    ${CMAKE_HOME_DIRECTORY}/include/videocapture.hpp
+    ${PROJECT_SOURCE_DIR}/include/videocapture.hpp
     
     # Defines
-    ${CMAKE_HOME_DIRECTORY}/include/defines.hpp
-    ${CMAKE_HOME_DIRECTORY}/include/videocapture_def.hpp
+    ${PROJECT_SOURCE_DIR}/include/defines.hpp
+    ${PROJECT_SOURCE_DIR}/include/videocapture_def.hpp
 )
 
 set(HEADERS_SENSORS
     # Base
-    ${CMAKE_HOME_DIRECTORY}/include/sensorcapture.hpp
+    ${PROJECT_SOURCE_DIR}/include/sensorcapture.hpp
 
     # Defines
-    ${CMAKE_HOME_DIRECTORY}/include/defines.hpp
-    ${CMAKE_HOME_DIRECTORY}/include/sensorcapture_def.hpp
+    ${PROJECT_SOURCE_DIR}/include/defines.hpp
+    ${PROJECT_SOURCE_DIR}/include/sensorcapture_def.hpp
 )
 
 include_directories(
-    ${CMAKE_HOME_DIRECTORY}/include
+    ${PROJECT_SOURCE_DIR}/include
 )
 
 ############################################################################
 # Required external libraries
 
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
+list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake")
 
 ############################################################################
 # Generate libraries
@@ -129,7 +129,7 @@ if(BUILD_EXAMPLES)
         include_directories(${OpenCV_INCLUDE_DIRS})
 
         ##### Video Example
-        add_executable(${PROJECT_NAME}_video_example "${CMAKE_HOME_DIRECTORY}/examples/zed_oc_video_example.cpp")
+        add_executable(${PROJECT_NAME}_video_example "${PROJECT_SOURCE_DIR}/examples/zed_oc_video_example.cpp")
         set_target_properties(${PROJECT_NAME}_video_example PROPERTIES PREFIX "")
         target_link_libraries(${PROJECT_NAME}_video_example
           ${PROJECT_NAME}
@@ -140,7 +140,7 @@ if(BUILD_EXAMPLES)
         )
 
         ##### Control Example
-        add_executable(${PROJECT_NAME}_control_example "${CMAKE_HOME_DIRECTORY}/examples/zed_oc_control_example.cpp")
+        add_executable(${PROJECT_NAME}_control_example "${PROJECT_SOURCE_DIR}/examples/zed_oc_control_example.cpp")
         set_target_properties(${PROJECT_NAME}_control_example PROPERTIES PREFIX "")
         target_link_libraries(${PROJECT_NAME}_control_example
           ${PROJECT_NAME}
@@ -151,8 +151,8 @@ if(BUILD_EXAMPLES)
         )
 
         ##### Rectify Example
-        include_directories( ${CMAKE_HOME_DIRECTORY}/examples/include)
-        add_executable(${PROJECT_NAME}_rectify_example "${CMAKE_HOME_DIRECTORY}/examples/zed_oc_rectify_example.cpp")
+        include_directories( ${PROJECT_SOURCE_DIR}/examples/include)
+        add_executable(${PROJECT_NAME}_rectify_example "${PROJECT_SOURCE_DIR}/examples/zed_oc_rectify_example.cpp")
         set_target_properties(${PROJECT_NAME}_rectify_example PROPERTIES PREFIX "")
         target_link_libraries(${PROJECT_NAME}_rectify_example
           ${PROJECT_NAME}
@@ -167,7 +167,7 @@ if(BUILD_EXAMPLES)
         message("* Sensors example available")
 
         ##### Sensors Example
-        add_executable(${PROJECT_NAME}_sensors_example "${CMAKE_HOME_DIRECTORY}/examples/zed_oc_sensors_example.cpp")
+        add_executable(${PROJECT_NAME}_sensors_example "${PROJECT_SOURCE_DIR}/examples/zed_oc_sensors_example.cpp")
         set_target_properties(${PROJECT_NAME}_sensors_example PROPERTIES PREFIX "")
         target_link_libraries(${PROJECT_NAME}_sensors_example          
           ${PROJECT_NAME}
@@ -181,7 +181,7 @@ if(BUILD_EXAMPLES)
         message("* Video/Sensors sync example available")
 
         ##### Synchronization Example
-        add_executable(${PROJECT_NAME}_sync_example "${CMAKE_HOME_DIRECTORY}/examples/zed_oc_sync_example.cpp")
+        add_executable(${PROJECT_NAME}_sync_example "${PROJECT_SOURCE_DIR}/examples/zed_oc_sync_example.cpp")
         set_target_properties(${PROJECT_NAME}_sync_example PROPERTIES PREFIX "")
         target_link_libraries(${PROJECT_NAME}_sync_example          
           ${PROJECT_NAME}

--- a/cmake/FindLIBUSB.cmake
+++ b/cmake/FindLIBUSB.cmake
@@ -132,7 +132,7 @@ if ( LibUSB_FOUND )
 
         try_compile(LibUSB_COMPILE_TEST_PASSED
                 ${CMAKE_BINARY_DIR}
-                "${CMAKE_SOURCE_DIR}/cmake/test-libusb-version.cpp"
+                "${PROJECT_SOURCE_DIR}/cmake/test-libusb-version.cpp"
                 CMAKE_FLAGS
                     "-DINCLUDE_DIRECTORIES=${LibUSB_INCLUDE_DIRS}"
                     "-DLINK_DIRECTORIES=${LibUSB_LIBRARIES}"


### PR DESCRIPTION
Right now some variables with `CMAKE_` prefix in the cmake build system will work only if this project is the root cmake project.
I propose following changes, which work great in my case and are probably a little more appropriate in general.

## Proposed change
Change `CMAKE_HOME_DIRECTORY` and `CMAKE_SOURCE_DIR` varaibles to `PROJECT_SOURCE_DIR`:
 - [Rationale1](https://cmake.org/cmake/help/latest/variable/CMAKE_HOME_DIRECTORY.html) `CMAKE_HOME_DIRECTORY` should not be used at all
 - [Rationale2](https://stackoverflow.com/questions/32028667/are-cmake-source-dir-and-project-source-dir-the-same-in-cmake/32030551) Using `PROJECT_SOURCE_DIR` allows embedding this library in external build system
 - **This does not change anything when compiling this repo as a standalone build.**
 - This allows embedding library sources along with cmake build infrastructure in external projects simply with cmake `ADD_SUBDIRECTORY` command.

## My usecase
My usecase is taking this library and placing it in my project in `lib/zed-open-capture/`, then in my `lib/CMakeLists.txt` I have:
```
SET(BUILD_EXAMPLES OFF CACHE BOOL "Build only the library")
ADD_SUBDIRECTORY(zed-open-capture)
```

Then in my root `CMakeLists.txt` by using things like:
```
ADD_SUBDIRECTORY(lib)

ADD_DEFINITIONS(-DVIDEO_MOD_AVAILABLE)
ADD_DEFINITIONS(-DSENSORS_MOD_AVAILABLE)
INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/lib/zed-open-capture/include)

TARGET_LINK_LIBRARIES(${PROJECT_NAME} zed_open_capture)
```
I can build my project, which successfully uses Open Capture Camera API.