### PR TITLE
Move closing brackets above preprocessor command.

### DIFF
--- a/include/sensorcapture.hpp
+++ b/include/sensorcapture.hpp
@@ -304,6 +304,9 @@ private:
 
 };
 
+}
+}
+
 #endif
 
 /** \example zed_oc_sensors_example.cpp
@@ -315,9 +318,5 @@ private:
  * Example of how to get synchronized video and sensors data from
  * the VideoCapture class and the SensorCapture class.
  */
-
-}
-}
-
 
 #endif // SENSORCAPTURE_HPP


### PR DESCRIPTION
Error when including sensorcapture.hpp

![image](https://user-images.githubusercontent.com/20051567/146046036-16c1d935-9ab0-47e8-a098-83486375f48a.png)

Simple fix in this PR. 